### PR TITLE
Inherit font weight for radio-list-item label

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -1,3 +1,7 @@
 blockquote {
     font-size: 14px;
 }
+
+.radio-list-item label {
+    font-weight: inherit;
+}


### PR DESCRIPTION
Syntax of `- ( ) MCQ Option` gets converted into a radio-list-item. The text is wrapped in label which style is bold in bootstrap style sheet.

Resolves https://github.com/MarkBind/markbind/issues/95