### PR TITLE
Rebuild included html per generate

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -62,7 +62,7 @@ Page.prototype.prepareTemplateData = function () {
   };
 };
 
-Page.prototype.generate = function () {
+Page.prototype.generate = function (builtFiles) {
   return new Promise((resolve, reject) => {
     this.markbinder.includeFile(this.sourcePath)
       .then(result => this.markbinder.resolveBaseUrl(result, {
@@ -94,7 +94,7 @@ Page.prototype.generate = function () {
         const resolvingFiles = [];
         unique(this.markbinder.getDynamicIncludeSrc()).forEach((source) => {
           if (!FsUtil.isUrl(source.to)) {
-            resolvingFiles.push(this.resolveDependency(source));
+            resolvingFiles.push(this.resolveDependency(source, builtFiles));
           }
         });
         return Promise.all(resolvingFiles);
@@ -128,23 +128,20 @@ Page.prototype.cleanUpDependency = function (file) {
  * Pre-render an external dynamic dependency to the same path as the current page
  * @param file
  */
-Page.prototype.resolveDependency = function (dependency) {
+Page.prototype.resolveDependency = function (dependency, builtFiles) {
   const source = dependency.from;
   const file = dependency.to;
   return new Promise((resolve, reject) => {
     const markbinder = new MarkBind();
     const resultDir = path.dirname(path.resolve(this.resultPath, path.relative(this.sourcePath, file)));
     const resultPath = path.join(resultDir, FsUtil.setExtension(path.basename(file), '._include_.html'));
-    let fileExists;
-    try {
-      fileExists = fs.statSync(resultPath).isFile();
-    } catch (e) {
-      fileExists = false;
-    }
-    // File exists, return.
-    if (fileExists) {
+
+    if (builtFiles[resultPath]) {
       return resolve();
     }
+
+    // eslint-disable-next-line no-param-reassign
+    builtFiles[resultPath] = true;
 
     let tempPath;
     if (FsUtil.isInRoot(this.rootPath, file)) {
@@ -178,7 +175,7 @@ Page.prototype.resolveDependency = function (dependency) {
         // Recursion call to resolve nested dependency
         const resolvingFiles = [];
         unique(markbinder.getDynamicIncludeSrc()).forEach((src) => {
-          if (!FsUtil.isUrl(src.to)) resolvingFiles.push(this.resolveDependency(src));
+          if (!FsUtil.isUrl(src.to)) resolvingFiles.push(this.resolveDependency(src, builtFiles));
         });
         return Promise.all(resolvingFiles);
       })

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -125,8 +125,10 @@ Page.prototype.cleanUpDependency = function (file) {
 };
 
 /**
- * Pre-render an external dynamic dependency to the same path as the current page
- * @param file
+ * Pre-render an external dynamic dependency
+ * Does not pre-render if file is already pre-rendered by another page during site generation
+ * @param dependency a map of the external dependency and where it is included
+ * @param builtFiles set of files already pre-rendered by another page
  */
 Page.prototype.resolveDependency = function (dependency, builtFiles) {
   const source = dependency.from;

--- a/lib/Site.js
+++ b/lib/Site.js
@@ -258,6 +258,7 @@ Site.prototype.generatePages = function () {
   // Run MarkBind include and render on each source file.
   // Render the final rendered page to the output folder.
   const { baseUrl } = this.siteConfig;
+  const builtFiles = {};
   const pages = this.siteConfig.pages || [];
   const processingFiles = [];
   const pageModels = pages.map(page => this.createPageData({
@@ -267,7 +268,7 @@ Site.prototype.generatePages = function () {
     pageTemplate: this.pageTemplate,
   }));
   pageModels.forEach((page) => {
-    processingFiles.push(page.generate());
+    processingFiles.push(page.generate(builtFiles));
   });
   return new Promise((resolve, reject) => {
     Promise.all(processingFiles)


### PR DESCRIPTION
Resolves https://github.com/MarkBind/markbind/issues/127

### Problem
Dynamically Included file is built based on whether the include.html exists.
During live reload, dynamically included files that are nested in other dynamically included files will  not reload due to the reason above.

### Solution
Do not decide to build file based on whether the include.html exists.
Instead maintain a set of all files built during page.generate().

### Considerations
The removed code is actually an optimization for the build process. Introducing the new heuristic only adds around 5- 10s of additional build time. However, live reload works as intended. As a comparison, removing the previous check which works adds 15-20s.

### Testing
1. build site once and save.
2. make changes to `\website-base\book\codeQuality\practices\useNameExplain\text.md`
3. `$ markbind serve`
4.  undo the change made in 2 while serving and wait for live reload
5. compare new _site with site in 1.