### PR TITLE
Remove clean up dependency

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -82,15 +82,6 @@ Page.prototype.generate = function (builtFiles) {
         return fs.outputFileAsync(this.resultPath, this.template(this.prepareTemplateData()));
       })
       .then(() => {
-        const cleaningUpFiles = [];
-        unique(this.markbinder.getDynamicIncludeSrc()).forEach((source) => {
-          if (!FsUtil.isUrl(source.to)) {
-            cleaningUpFiles.push(this.cleanUpDependency(source.to));
-          }
-        });
-        return Promise.all(cleaningUpFiles);
-      })
-      .then(() => {
         const resolvingFiles = [];
         unique(this.markbinder.getDynamicIncludeSrc()).forEach((source) => {
           if (!FsUtil.isUrl(source.to)) {
@@ -101,26 +92,6 @@ Page.prototype.generate = function (builtFiles) {
       })
       .then(resolve)
       .catch(reject);
-  });
-};
-
-/**
- * Clean up the existing included dynamic dependency files and render them again.
- * @param file
- */
-Page.prototype.cleanUpDependency = function (file) {
-  return new Promise((resolve, reject) => {
-    const resultDir = path.dirname(path.resolve(this.resultPath, path.relative(this.sourcePath, file)));
-    const resultPath = path.join(resultDir, FsUtil.setExtension(path.basename(file), '._include_.html'));
-    try {
-      fs.statSync(resultPath).isFile();
-      // File existed. Remove it.
-      fs.removeAsync(resultPath)
-        .then(resolve)
-        .catch(reject);
-    } catch (e) {
-      resolve();
-    }
   });
 };
 


### PR DESCRIPTION
Since we are maintaining a set for built files to check if we need to rebuild a file, `cleanUpDependency` is now redundant.

Should speed up process as there is less IO operations.

Follows #21.
Related https://github.com/MarkBind/markbind/issues/88