### PR TITLE
Update gh-pages to v1.1.0

### DIFF
--- a/lib/Site.js
+++ b/lib/Site.js
@@ -348,6 +348,7 @@ Site.prototype.deploy = function () {
     message: 'Site Update.',
     repo: '',
   };
+  process.env.NODE_DEBUG = 'gh-pages';
   return new Promise((resolve, reject) => {
     const publish = Promise.promisify(ghpages.publish);
     this.readSiteConfig()
@@ -362,7 +363,6 @@ Site.prototype.deploy = function () {
         options.branch = this.siteConfig.deploy.branch || defaultDeployConfig.branch;
         options.message = this.siteConfig.deploy.message || defaultDeployConfig.message;
         options.repo = this.siteConfig.deploy.repo || defaultDeployConfig.repo;
-        options.logger = logger.info;
         return publish(basePath, options);
       })
       .then(resolve)

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8="
     },
     "async": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
-      "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -179,6 +179,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
     },
     "basic-auth": {
       "version": "1.1.0",
@@ -358,14 +363,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "collections": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
-      "integrity": "sha1-HyMCay7zb5J+7MkB6ZxfDUj6M04=",
-      "requires": {
-        "weak-map": "1.0.0"
-      }
     },
     "color-convert": {
       "version": "1.9.1",
@@ -1939,31 +1936,44 @@
       "dev": true
     },
     "gh-pages": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.12.0.tgz",
-      "integrity": "sha1-2VHj7Zi4VpnUsEGOsaFbGgSYjcE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.1.0.tgz",
+      "integrity": "sha512-ZpDkeOVmIrN5mz+sBWDz5zmTqcbNJzI/updCwEv/7rrSdpTNlj1B5GhBqG7f4Q8p5sJOdnBV0SIqxJrxtZQ9FA==",
       "requires": {
-        "async": "2.1.2",
-        "commander": "2.9.0",
+        "async": "2.6.0",
+        "base64url": "2.0.0",
+        "commander": "2.11.0",
+        "fs-extra": "4.0.3",
         "globby": "6.1.0",
-        "graceful-fs": "4.1.10",
-        "q": "1.4.1",
-        "q-io": "1.13.2",
-        "rimraf": "2.6.1"
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.10",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz",
-          "integrity": "sha1-8tcgwiCS90Mih3XHXjYSYyUB8TE="
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "requires": {
+            "glob": "7.1.2"
+          }
         }
       }
     },
@@ -2019,11 +2029,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "has": {
       "version": "1.0.1",
@@ -2712,11 +2717,6 @@
         "regex-cache": "0.4.3"
       }
     },
-    "mime": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-      "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
-    },
     "mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
@@ -2729,11 +2729,6 @@
       "requires": {
         "mime-db": "1.27.0"
       }
-    },
-    "mimeparse": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
-      "integrity": "sha1-2vsCdSNw/SJgk64xUsJxrwGsJUo="
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -3109,29 +3104,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "q": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
-    },
-    "q-io": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.13.2.tgz",
-      "integrity": "sha1-7qEw1IHdteGqG8WmaFX3OR0G8AM=",
-      "requires": {
-        "collections": "0.2.2",
-        "mime": "1.3.6",
-        "mimeparse": "0.1.4",
-        "q": "1.4.1",
-        "qs": "1.2.2",
-        "url2": "0.0.0"
-      }
-    },
-    "qs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-      "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -3667,6 +3639,11 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
       "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
     },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
     "unix-crypt-td-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz",
@@ -3676,11 +3653,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "url2": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
-      "integrity": "sha1-Tqq9HVw6yQ1iq0SFyZhCKGWgSxo="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3720,11 +3692,6 @@
         "ensure-posix-path": "1.0.2",
         "matcher-collection": "1.0.4"
       }
-    },
-    "weak-map": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
-      "integrity": "sha1-tm5Wqd8L0lp2u/G1FNsSkIBhSjc="
     },
     "websocket-driver": {
       "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ejs": "^2.5.5",
     "figlet": "^1.2.0",
     "fs-extra-promise": "^0.4.1",
-    "gh-pages": "^0.12.0",
+    "gh-pages": "^1.1.0",
     "ignore": "^3.2.0",
     "js-beautify": "^1.6.12",
     "live-server": "^1.2.0",


### PR DESCRIPTION
Repositories now have their own dedicated cache.

Resolves https://github.com/MarkBind/markbind/issues/141

Tested:
![image](https://user-images.githubusercontent.com/22221132/36598283-9f239d16-18e6-11e8-8306-c14f0ca3a48f.png)
