### PR TITLE
Add vertical lines to tables

### DIFF
--- a/asset/css/markbind.css
+++ b/asset/css/markbind.css
@@ -2,8 +2,17 @@ blockquote {
     font-size: 14px;
 }
 
+.markbind-table {
+    width: auto;
+}
+
 .radio-list-item label {
     font-weight: inherit;
+}
+
+.table-striped > thead,
+.table-striped > tbody > tr:nth-of-type(even) {
+    background-color: #fff;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/149
Follows https://github.com/MarkBind/markbind/pull/161
Add vertica lines between table columns. Also updates display to block so that the table is compact

Here are some comparisons (old on left, new on right)
![image](https://user-images.githubusercontent.com/22221132/36931135-0d5adf74-1eeb-11e8-9a70-4bcd1e8264cd.png)
![image](https://user-images.githubusercontent.com/22221132/36931137-12b6129a-1eeb-11e8-87ba-34fa01e93878.png)
![image](https://user-images.githubusercontent.com/22221132/36931140-18303c6e-1eeb-11e8-953a-f52002a47e88.png)

Kept to the same styling (instead of the github markdown styling) to be consistent with the overall look.
