### PR TITLE
Add htmlparser2 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "figlet": "^1.2.0",
     "fs-extra-promise": "^0.4.1",
     "gh-pages": "^1.1.0",
+    "htmlparser2": "MarkBind/htmlparser2#v3.10.0-markbind.1",
     "ignore": "^3.2.0",
     "js-beautify": "^1.6.12",
     "live-server": "^1.2.0",


### PR DESCRIPTION
Resolves https://github.com/MarkBind/markbind/issues/166

This PR aims to ensure that users of the published npm package are using the forked version of `htmlparser2` at https://github.com/MarkBind/htmlparser2 instead of the original version.

As cheerio was added as a dependency to `markbind-cli` in v1.6.0, `markbind` relied on the old version of `htmlparser2` to render content which resulted in the angled bracket parsing problem coming back.